### PR TITLE
[FEAT] #33 로그아웃 api 구현

### DIFF
--- a/src/main/java/com/abcdedu_backend/member/controller/AuthController.java
+++ b/src/main/java/com/abcdedu_backend/member/controller/AuthController.java
@@ -68,6 +68,21 @@ public class AuthController {
         LoginResponse loginResponse = new LoginResponse(loginTokenDto.accessToken());
         return Response.success(loginResponse);
     }
+    @Operation(summary = "로그아웃", description = "로그아웃을 합니다.")
+    @DeleteMapping("/logout")
+    public Response<LoginResponse> logout(HttpServletRequest request, HttpServletResponse response){
+        String refreshToken = parseRefreshToken(request);
+        memberService.logout(refreshToken);
+        ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshToken", "")
+                .httpOnly(true)
+                .path("/")
+                .maxAge(0)
+                .build();
+        response.setHeader("Set-Cookie", refreshTokenCookie.toString());
+        return Response.success();
+    }
+
+
 
     @Operation(summary = "액세스 토큰 재발급", description = "리프레시 토큰으로 액세스 토큰을 재발급 합니다.")
     @ApiResponses(value ={
@@ -76,13 +91,18 @@ public class AuthController {
     })
     @GetMapping("/reissue")
     public Response<ReissueResponse> reissue(HttpServletRequest request) {
+        String refreshToken = parseRefreshToken(request);
+        ReissueResponse reissueResponse = memberService.reissue(refreshToken);
+        return Response.success(reissueResponse);
+    }
+
+    private String parseRefreshToken(HttpServletRequest request) {
         Cookie refreshTokenCookie = Arrays.stream(request.getCookies())
                 .filter(cookie -> "refreshToken".equals(cookie.getName()))
                 .findFirst()
                 .orElseThrow(() -> new ApplicationException(ErrorCode.TOKEN_NOT_FOUND));
         String refreshToken = refreshTokenCookie.getValue();
-        ReissueResponse reissueResponse = memberService.reissue(refreshToken);
-        return Response.success(reissueResponse);
+        return refreshToken;
     }
 
 }

--- a/src/main/java/com/abcdedu_backend/member/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/abcdedu_backend/member/repository/RefreshTokenRepository.java
@@ -4,4 +4,5 @@ import com.abcdedu_backend.member.entity.RefreshToken;
 import org.springframework.data.repository.CrudRepository;
 
 public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
+
 }

--- a/src/main/java/com/abcdedu_backend/member/service/MemberService.java
+++ b/src/main/java/com/abcdedu_backend/member/service/MemberService.java
@@ -143,4 +143,9 @@ public class MemberService {
                 .role(findMember.getRole().getName())
                 .build();
     }
+
+    @Transactional
+    public void logout(String refreshToken) {
+        refreshTokenRepository.deleteById(refreshToken);
+    }
 }

--- a/src/main/java/com/abcdedu_backend/utils/JwtUtil.java
+++ b/src/main/java/com/abcdedu_backend/utils/JwtUtil.java
@@ -14,7 +14,7 @@ import java.util.Date;
 @Component
 public class JwtUtil {
 
-    private Long ACCESS_TOKEN_EXPIRED_MS = Duration.ofHours(2).toMillis();
+    private Long ACCESS_TOKEN_EXPIRED_MS = Duration.ofMinutes(30).toMillis();
     private Long REFRESH_TOKEN_EXPIRED_MS = Duration.ofDays(14).toMillis();
     private static final String MEMBER_ID_KEY = "memberId";
 


### PR DESCRIPTION
## 📝작업 목록
- [x] 로그아웃 구현


## 💬기타
블랙리스트 방식을 고려했는데, accessToken을 저장하는것 까지 하게되면 세션방식과 크게 다르지 않는다고 생각해서 accessToken 만료 시간을 30분으로 줄이는 방식으로 수정했습니다.
### 코드리뷰 룰
- P1: 꼭 반영해주세요 (Request changes)
- P2: 적극적으로 고려해주세요 (Request changes)
- P3: 웬만하면 반영해 주세요 (Comment)
- P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- P5: 그냥 사소한 의견입니다 (Approve)
- 참고: https://blog.banksalad.com/tech/banksalad-code-review-culture/