### PR TITLE
[FIX] 쿠키로 인한 로그인 에러 해결

### DIFF
--- a/src/main/java/com/abcdedu_backend/member/controller/AuthController.java
+++ b/src/main/java/com/abcdedu_backend/member/controller/AuthController.java
@@ -46,8 +46,6 @@ public class AuthController {
     private String cookieSameSite;
     @Value("${cookie.secure}")
     private boolean isCookieHttpSecure;
-    @Value("${cookie.domain}")
-    private String cookieDomain;
 
     private final MemberService memberService;
 
@@ -99,7 +97,6 @@ public class AuthController {
                 .maxAge(maxAge)
                 .sameSite(cookieSameSite)
                 .secure(isCookieHttpSecure)
-                .domain(cookieDomain)
                 .build();
         response.setHeader("Set-Cookie", refreshTokenCookie.toString());
     }


### PR DESCRIPTION
## 📝작업 목록
- [x] 로그아웃 시 잘못 발급된 쿠키 삭제 코드 추가
## 💬기타
이전 쿠키 도메인 변경으로 Name: refreshToken 인 쿠키가 다른 도메인으로 두개가 생겨서 에러가 발생하고 있어 잠시 지우기 위해 수정합니다.
나중에 변경된 코드 삭제 예정.
### 코드리뷰 룰
- P1: 꼭 반영해주세요 (Request changes)
- P2: 적극적으로 고려해주세요 (Request changes)
- P3: 웬만하면 반영해 주세요 (Comment)
- P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- P5: 그냥 사소한 의견입니다 (Approve)
- 참고: https://blog.banksalad.com/tech/banksalad-code-review-culture/