### PR TITLE
[FIX] 레디스 및 테스트 환경 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,9 +65,20 @@ dependencies {
 
     // Test용 Gson추가
     testImplementation 'com.google.code.gson:gson:2.11.0'
+
+    // Test용 redis 추가
+    testImplementation "org.testcontainers:testcontainers:1.19.0"
+    testImplementation "org.testcontainers:junit-jupiter:1.19.0"
+
+
+
 }
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+test {
+    systemProperty 'spring.profiles.active', 'test'
 }
 

--- a/src/main/java/com/abcdedu_backend/lecture/controller/LectureController.java
+++ b/src/main/java/com/abcdedu_backend/lecture/controller/LectureController.java
@@ -98,7 +98,8 @@ public class LectureController {
     @PatchMapping("/file/{assignmentFileId}")
     public Response<Void> updateAssignmentFile(@PathVariable Long assignmentFileId,
                                                      @JwtValidation Long memberId,
-                                                     @RequestPart("file") MultipartFile file){
+                                                     @RequestPart("file") MultipartFile multipartFile){
+        File file = FileUtil.convertToFile(multipartFile);
         lectureService.updateAssignmentFile(memberId, assignmentFileId, file);
         return Response.success();
     }
@@ -109,7 +110,8 @@ public class LectureController {
     @PatchMapping("/answer-file/{assignmentAnswerFileId}")
     public Response<Void> updateAssignmentAnswerFile(@PathVariable Long assignmentAnswerFileId,
                                                      @JwtValidation Long memberId,
-                                                     @RequestPart("file") MultipartFile file){
+                                                     @RequestPart("file") MultipartFile multipartFile){
+        File file = FileUtil.convertToFile(multipartFile);
         lectureService.updateAssignmentAnswerFile(memberId, assignmentAnswerFileId, file);
         return Response.success();
     }

--- a/src/main/java/com/abcdedu_backend/lecture/service/LectureService.java
+++ b/src/main/java/com/abcdedu_backend/lecture/service/LectureService.java
@@ -168,7 +168,7 @@ public class LectureService {
     }
 
     @Transactional
-    public void updateAssignmentFile(Long memberId, Long assignmentFileId, MultipartFile file) {
+    public void updateAssignmentFile(Long memberId, Long assignmentFileId, File file) {
         Member findMember = memberService.checkMember(memberId);
         checkAdminPermission(findMember);
         AssignmentFile assignmentFile = findAssignmentFile(assignmentFileId);
@@ -183,7 +183,7 @@ public class LectureService {
     }
 
     @Transactional
-    public void updateAssignmentAnswerFile(Long memberId, Long assignmentAnswerFileId, MultipartFile file) {
+    public void updateAssignmentAnswerFile(Long memberId, Long assignmentAnswerFileId, File file) {
         Member findMember = memberService.checkMember(memberId);
         checkAdminPermission(findMember);
         AssignmentAnswerFile assignmentAnswerFile = findAssignmentAnswerFile(assignmentAnswerFileId);

--- a/src/test/java/com/abcdedu_backend/config/RedisTestContainer.java
+++ b/src/test/java/com/abcdedu_backend/config/RedisTestContainer.java
@@ -1,0 +1,26 @@
+package com.abcdedu_backend.config;
+
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+public class RedisTestContainer implements BeforeAllCallback {
+
+    private static final String REDIS_HOST_PATH = "spring.data.redis.host";
+    private static final String REDIS_PORT_PATH = "spring.data.redis.port";
+    private static final String REDIS_DOCKER_IMAGE = "redis:7.0.7-alpine";
+
+    private static final GenericContainer<?> redisContainer = new GenericContainer<>(REDIS_DOCKER_IMAGE)
+            .withExposedPorts(6379);
+
+    @Override
+    public void beforeAll(ExtensionContext context) {
+        redisContainer.start();
+
+        // Redis 연결 정보 설정
+        System.setProperty(REDIS_HOST_PATH, redisContainer.getHost());
+        System.setProperty(REDIS_PORT_PATH, redisContainer.getFirstMappedPort().toString());
+    }
+}

--- a/src/test/java/com/abcdedu_backend/member/repository/RefreshTokenRepositoryTest.java
+++ b/src/test/java/com/abcdedu_backend/member/repository/RefreshTokenRepositoryTest.java
@@ -1,7 +1,9 @@
 package com.abcdedu_backend.member.repository;
 
+import com.abcdedu_backend.config.RedisTestContainer;
 import com.abcdedu_backend.member.entity.RefreshToken;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -11,6 +13,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.*;
 
 @SpringBootTest
+@ExtendWith(RedisTestContainer.class)
 @ActiveProfiles("test")
 public class RefreshTokenRepositoryTest {
 


### PR DESCRIPTION
## 📝작업 목록
- [x] redis testcontainer적용
- [x] 테스트 환경 설정(테스트 시 application-test.yaml 적용)

## 💬기타
redis 테스트를 진행할 때 사용할 h2같은 db가 필요한데, embeded와 testcontainer중 고민하다 testcontainer를 선택했습니다. embeded는 편리하긴해도 [it.ozimov](https://github.com/ozimov/embedded-redis) 지원이 끝난지 너무 오래되기도 했고, 
m1이나 window에서는 적용안된다고 해서 testcontainer를 선택했습니다.
### 코드리뷰 룰
- P1: 꼭 반영해주세요 (Request changes)
- P2: 적극적으로 고려해주세요 (Request changes)
- P3: 웬만하면 반영해 주세요 (Comment)
- P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- P5: 그냥 사소한 의견입니다 (Approve)
- 참고: https://blog.banksalad.com/tech/banksalad-code-review-culture/