### PR TITLE
[FEAT] #139 #140 이메일 인증 및 비밀번호 변경 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,9 @@ dependencies {
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-mysql'
 
+    // email 인증 의존성 추가
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/abcdedu_backend/configs/EmailConfig.java
+++ b/src/main/java/com/abcdedu_backend/configs/EmailConfig.java
@@ -1,0 +1,51 @@
+package com.abcdedu_backend.configs;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+public class EmailConfig {
+    @Value("${mail.host}")
+    private String host;
+
+    @Value("${mail.port}")
+    private int port;
+
+    @Value("${mail.username}")
+    private String username;
+
+    @Value("${mail.password}")
+    private String password;
+
+    @Value("${mail.properties.mail.smtp.auth}")
+    private boolean auth;
+
+    @Value("${mail.properties.mail.smtp.timeout}")
+    private int timeout;
+
+    @Value("${mail.properties.mail.smtp.starttls.enable}")
+    private boolean starttlsEnable;
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost(host);
+        mailSender.setPort(port);
+        mailSender.setUsername(username);
+        mailSender.setPassword(password);
+
+        Properties props = mailSender.getJavaMailProperties();
+        props.put("mail.transport.protocol", "smtp");
+        props.put("mail.smtp.auth", auth);
+        props.put("mail.smtp.timeout", timeout);
+        props.put("mail.smtp.starttls.enable", starttlsEnable);
+        props.put("mail.debug", "true");
+
+        return mailSender;
+    }
+}

--- a/src/main/java/com/abcdedu_backend/configs/EmailConfig.java
+++ b/src/main/java/com/abcdedu_backend/configs/EmailConfig.java
@@ -44,7 +44,6 @@ public class EmailConfig {
         props.put("mail.smtp.auth", auth);
         props.put("mail.smtp.timeout", timeout);
         props.put("mail.smtp.starttls.enable", starttlsEnable);
-        props.put("mail.debug", "true");
 
         return mailSender;
     }

--- a/src/main/java/com/abcdedu_backend/exception/ErrorCode.java
+++ b/src/main/java/com/abcdedu_backend/exception/ErrorCode.java
@@ -65,7 +65,13 @@ public enum ErrorCode {
     HOMEWORK_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 공통과제를 찾을 수 없습니다."),
 
     //파일 에러
-    FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "파일이 존재하지 않습니다.");
+    FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "파일이 존재하지 않습니다."),
+
+    //email 에러
+    EMAIL_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 인증에 실패하였습니다."),
+    CODE_MISMATCH(HttpStatus.BAD_REQUEST, "인증 코드가 일치하지 않습니다."),
+    EMAIL_CODE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 이메일로 등록된 코드가 존재하지 않습니다.");
+
 
     private HttpStatus status;
     private String message;

--- a/src/main/java/com/abcdedu_backend/exception/ErrorCode.java
+++ b/src/main/java/com/abcdedu_backend/exception/ErrorCode.java
@@ -39,6 +39,7 @@ public enum ErrorCode {
     //회원
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 유저입니다."),
     LOGIN_FAILED(HttpStatus.BAD_REQUEST, "존재하지 않는 이메일 또는 비밀번호입니다."),
+    EMAIL_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 이메일입니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다."),
     INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 액세스 토큰입니다."),
     TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "토큰이 존재하지 않습니다."),

--- a/src/main/java/com/abcdedu_backend/exception/ErrorCode.java
+++ b/src/main/java/com/abcdedu_backend/exception/ErrorCode.java
@@ -39,7 +39,7 @@ public enum ErrorCode {
     //회원
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 유저입니다."),
     LOGIN_FAILED(HttpStatus.BAD_REQUEST, "존재하지 않는 이메일 또는 비밀번호입니다."),
-    EMAIL_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 이메일입니다."),
+    EMAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 이메일입니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다."),
     INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 액세스 토큰입니다."),
     TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "토큰이 존재하지 않습니다."),

--- a/src/main/java/com/abcdedu_backend/member/controller/EmailController.java
+++ b/src/main/java/com/abcdedu_backend/member/controller/EmailController.java
@@ -1,0 +1,49 @@
+package com.abcdedu_backend.member.controller;
+
+import com.abcdedu_backend.member.dto.request.SendEmailCodeRequest;
+import com.abcdedu_backend.member.service.EmailService;
+import com.abcdedu_backend.utils.Response;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/mail")
+@RequiredArgsConstructor
+@ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "성공적으로 요청이 완료되었습니다."),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청입니다. (RequestBody Validation)", content = @Content),
+        @ApiResponse(responseCode = "500", description = "서버 에러", content = @Content)
+})
+@Tag(name = "이메일 인증 기능", description = "이메일 인증 기능입니다.")
+public class EmailController {
+    private final EmailService emailService;
+
+    @Operation(summary = "인증 메일 전송", description = "인증 메일을 전송합니다.")
+    @ApiResponses(value ={
+            @ApiResponse(responseCode = "500", description = "이메일 인증 메일 전송 실패하였습니다.", content = @Content)
+    })
+    @PostMapping("/code")
+    public Response<Void> sendCode(@Valid @RequestBody SendEmailCodeRequest sendEmailCodeRequest){
+        emailService.sendCodeToEmail(sendEmailCodeRequest.email());
+        return Response.success();
+    }
+
+    @Operation(summary = "인증 코드 체크", description = "인증 코드를 체크합니다.")
+    @ApiResponses(value ={
+            @ApiResponse(responseCode = "400", description = "코드가 일치하지 않습니다.", content = @Content),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 이메일입니다.", content = @Content)
+    })
+    @GetMapping("/code")
+    public Response<Void> codeVerification(@RequestParam String email, @RequestParam String code){
+        emailService.checkCode(email, code);
+        return Response.success();
+    }
+}

--- a/src/main/java/com/abcdedu_backend/member/controller/MemberInfoController.java
+++ b/src/main/java/com/abcdedu_backend/member/controller/MemberInfoController.java
@@ -72,7 +72,7 @@ public class MemberInfoController {
     }
 
     @ApiResponses(value ={
-            @ApiResponse(responseCode = "404", description = "존재하지 않는 유저입니다.", content = @Content),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 이메일입니다.", content = @Content),
     })
     @Operation(summary = "비밀번호 수정", description = "비밀번호를 수정합니다.")
     @PatchMapping("/password")

--- a/src/main/java/com/abcdedu_backend/member/controller/MemberInfoController.java
+++ b/src/main/java/com/abcdedu_backend/member/controller/MemberInfoController.java
@@ -2,6 +2,7 @@ package com.abcdedu_backend.member.controller;
 
 import com.abcdedu_backend.common.jwt.JwtValidation;
 import com.abcdedu_backend.member.dto.request.UpdateMemberInfoRequest;
+import com.abcdedu_backend.member.dto.request.UpdatePasswordRequest;
 import com.abcdedu_backend.member.dto.response.MemberBasicInfoResponse;
 import com.abcdedu_backend.member.dto.response.MemberInfoResponse;
 import com.abcdedu_backend.member.dto.response.MemberNameAndRoleResponse;
@@ -68,5 +69,15 @@ public class MemberInfoController {
     public Response<MemberBasicInfoResponse> getMemberBasicInfo(@JwtValidation Long memberId){
         MemberBasicInfoResponse memberBasicInfoResponse = memberService.getMemberBasicInfo(memberId);
         return Response.success(memberBasicInfoResponse);
+    }
+
+    @ApiResponses(value ={
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 유저입니다.", content = @Content),
+    })
+    @Operation(summary = "비밀번호 수정", description = "비밀번호를 수정합니다.")
+    @PatchMapping("/password")
+    public Response<Void> updatePassword(@Valid @RequestBody UpdatePasswordRequest updatePasswordRequest){
+        memberService.updatePassword(updatePasswordRequest.email(), updatePasswordRequest.newPassword());
+        return Response.success();
     }
 }

--- a/src/main/java/com/abcdedu_backend/member/dto/request/SendEmailCodeRequest.java
+++ b/src/main/java/com/abcdedu_backend/member/dto/request/SendEmailCodeRequest.java
@@ -1,0 +1,11 @@
+package com.abcdedu_backend.member.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
+
+public record SendEmailCodeRequest (
+        @Email
+        @NotNull
+        String email
+){
+}

--- a/src/main/java/com/abcdedu_backend/member/dto/request/UpdatePasswordRequest.java
+++ b/src/main/java/com/abcdedu_backend/member/dto/request/UpdatePasswordRequest.java
@@ -1,0 +1,15 @@
+package com.abcdedu_backend.member.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record UpdatePasswordRequest (
+        @Email
+        @NotBlank(message = "값이 비어있습니다.")
+        String email,
+        @Size(min = 6, max = 20, message = "패스워드의 길이는 6~20이어야 합니다.")
+        @NotBlank(message = "값이 비어있습니다.")
+        String newPassword
+){
+}

--- a/src/main/java/com/abcdedu_backend/member/entity/EmailCode.java
+++ b/src/main/java/com/abcdedu_backend/member/entity/EmailCode.java
@@ -1,0 +1,16 @@
+package com.abcdedu_backend.member.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+@Getter
+@AllArgsConstructor
+@RedisHash(value = "email_code", timeToLive = 300)
+public class EmailCode {
+
+    @Id
+    private String email;
+    private String code;
+}

--- a/src/main/java/com/abcdedu_backend/member/entity/Member.java
+++ b/src/main/java/com/abcdedu_backend/member/entity/Member.java
@@ -72,4 +72,8 @@ public class Member extends BaseTimeEntity {
         this.role = memberRole;
     }
 
+    public void updatePassword(String newEncodedPassword){
+        this.encodedPassword = newEncodedPassword;
+    }
+
 }

--- a/src/main/java/com/abcdedu_backend/member/repository/EmailCodeRepository.java
+++ b/src/main/java/com/abcdedu_backend/member/repository/EmailCodeRepository.java
@@ -1,0 +1,7 @@
+package com.abcdedu_backend.member.repository;
+
+import com.abcdedu_backend.member.entity.EmailCode;
+import org.springframework.data.repository.CrudRepository;
+
+public interface EmailCodeRepository extends CrudRepository<EmailCode, String> {
+}

--- a/src/main/java/com/abcdedu_backend/member/service/EmailService.java
+++ b/src/main/java/com/abcdedu_backend/member/service/EmailService.java
@@ -1,0 +1,58 @@
+package com.abcdedu_backend.member.service;
+
+import com.abcdedu_backend.exception.ApplicationException;
+import com.abcdedu_backend.exception.ErrorCode;
+import com.abcdedu_backend.member.entity.EmailCode;
+import com.abcdedu_backend.member.repository.EmailCodeRepository;
+import com.abcdedu_backend.utils.RandomCodeGenerator;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+    private final JavaMailSender emailSender;
+    private final RandomCodeGenerator randomCodeGenerator;
+    private final EmailCodeRepository emailCodeRepository;
+
+    private static final String TITLE = "[ABCDEdu] 회원 가입 인증 이메일 입니다.";
+    private static final String TEXT_FORM = "인증번호는 <b>%s</b> 입니다.";
+
+    public void sendCodeToEmail(String toEmail) {
+        String code = randomCodeGenerator.generateAuthCode();
+        String text = String.format(TEXT_FORM, code);
+
+        try {
+            MimeMessage emailForm = createEmailForm(toEmail, TITLE, text);
+            emailSender.send(emailForm);
+            emailCodeRepository.save(new EmailCode(toEmail, code));
+        } catch (Exception e) {
+            throw new ApplicationException(ErrorCode.EMAIL_SEND_FAILED);
+        }
+    }
+
+    public void checkCode(String email, String code) {
+        EmailCode emailCode = emailCodeRepository.findById(email)
+                .orElseThrow(() -> new ApplicationException(ErrorCode.EMAIL_CODE_NOT_FOUND));
+
+        if (!Objects.equals(code, emailCode.getCode())) {
+            throw new ApplicationException(ErrorCode.CODE_MISMATCH);
+        }
+    }
+
+    private MimeMessage createEmailForm(String toEmail, String title, String text) throws MessagingException {
+        MimeMessage message = emailSender.createMimeMessage();
+        MimeMessageHelper helper = new MimeMessageHelper(message, "UTF-8");
+        helper.setTo(toEmail);
+        helper.setSubject(title);
+        helper.setText(text, true);
+
+        return message;
+    }
+}

--- a/src/main/java/com/abcdedu_backend/member/service/MemberService.java
+++ b/src/main/java/com/abcdedu_backend/member/service/MemberService.java
@@ -167,4 +167,13 @@ public class MemberService {
             throw new ApplicationException(ErrorCode.ADMIN_VALID_PERMISSION);
         }
     }
+
+    @Transactional
+    public void updatePassword(String email, String newPassword) {
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new ApplicationException(ErrorCode.EMAIL_NOT_FOUND));
+
+        String newEncodedPassword = passwordEncoder.encode(newPassword);
+        member.updatePassword(newEncodedPassword);
+    }
 }

--- a/src/main/java/com/abcdedu_backend/utils/RandomCodeGenerator.java
+++ b/src/main/java/com/abcdedu_backend/utils/RandomCodeGenerator.java
@@ -1,0 +1,24 @@
+package com.abcdedu_backend.utils;
+
+import org.springframework.stereotype.Component;
+
+import java.security.SecureRandom;
+
+@Component
+public class RandomCodeGenerator {
+
+    private static final String CHAR_SET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+    private static final int CODE_LENGTH = 6;
+
+    public String generateAuthCode() {
+        SecureRandom random = new SecureRandom();
+        StringBuilder authCode = new StringBuilder(CODE_LENGTH);
+
+        for (int i = 0; i < CODE_LENGTH; i++) {
+            int randomIndex = random.nextInt(CHAR_SET.length());
+            authCode.append(CHAR_SET.charAt(randomIndex));
+        }
+
+        return authCode.toString();
+    }
+}

--- a/src/test/java/com/abcdedu_backend/member/service/MemberServiceTest.java
+++ b/src/test/java/com/abcdedu_backend/member/service/MemberServiceTest.java
@@ -242,6 +242,19 @@ class MemberServiceTest {
         assertThat(memberBasicInfoResponse.email()).isEqualTo(member.getEmail());
     }
 
+    @Test
+    public void 비밀번호_변경_성공() {
+        Member member = createMember();
+        doReturn(Optional.of(member)).when(memberRepository).findByEmail(member.getEmail());
+        doReturn("newEncodedPassword").when(passwordEncoder).encode("123456");
+
+        target.updatePassword(member.getEmail(), "123456");
+
+        verify(memberRepository, times(1)).findByEmail(member.getEmail());
+        verify(passwordEncoder, times(1)).encode("123456");
+        assertThat(member.getEncodedPassword()).isEqualTo("newEncodedPassword");
+    }
+
 
     @Test
     public void 로그아웃_성공() {


### PR DESCRIPTION
## 📝작업 목록
- [x] 이메일 인증 api 추가
- [x] 이메일 체크 api 추가
- [x] 비밀번호 변경 api 추가

## 💬기타
- 이메일 인증 비밀번호(abcdedu@gmail.com) 생성되면 바로 추가하겠습니다.
- 이메일 보낼 때 이런식으로 보내지는데 문구 확인 부탁드려요!
<img width="178" alt="image" src="https://github.com/user-attachments/assets/1c944be2-fe88-4ee3-a5f9-cd31e8d96503">

- redis ttl 활용해서 5분간만 인증 되도록 적용했습니다.
- 패스워드 변경 로직은 지금 이메일, 패스워드 받으면 바로 적용되게 하는데 나중에 보안에 문제가 될 수 있을것같아요. 그래서 나중에 이메일 인증 후에 10분정도만 패스워드를 변경할 수 있거나 하는 로직을 추가해볼까 합니다.
- 클린 아키텍처는 이거 머지되며는 전체적으로 리팩토링하면서 해보겠습니다.

### 코드리뷰 룰
- P1: 꼭 반영해주세요 (Request changes)
- P2: 적극적으로 고려해주세요 (Request changes)
- P3: 웬만하면 반영해 주세요 (Comment)
- P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- P5: 그냥 사소한 의견입니다 (Approve)
- 참고: https://blog.banksalad.com/tech/banksalad-code-review-culture/