### PR TITLE
[FEAT] 공통 과제 CRUD API 명세, 대표 공통과제 지정 및 조회

### DIFF
--- a/src/main/java/com/abcdedu_backend/exception/ErrorCode.java
+++ b/src/main/java/com/abcdedu_backend/exception/ErrorCode.java
@@ -67,6 +67,7 @@ public enum ErrorCode {
 
     // 공통 과제
     HOMEWORK_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 공통과제를 찾을 수 없습니다."),
+    REPRESENTATIVE_HOMEWORK_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 대표 공통과제를 찾을 수 없습니다."),
 
     //파일 에러
     FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "파일이 존재하지 않습니다."),

--- a/src/main/java/com/abcdedu_backend/homework/controller/AdminHomeworkController.java
+++ b/src/main/java/com/abcdedu_backend/homework/controller/AdminHomeworkController.java
@@ -28,9 +28,9 @@ public class AdminHomeworkController {
     private final HomeworkAdminService homeworkAdminService;
 
     @Operation(summary = "대표 공통과제 등록", description = "메인에 과제로 띄울 대표 버전을 선택한다.")
-    @PostMapping("/representative/{homeworkId}")
+    @PostMapping("/representative")
     public Response<Void> registerRepresentative(@Valid @RequestBody RepresentativeRegisterRequest request) {
-        // homeworkAdminService.registerAsRepresentative(request);
+        homeworkAdminService.registerAsRepresentative(request);
         return Response.success();
     }
 

--- a/src/main/java/com/abcdedu_backend/homework/controller/AdminHomeworkController.java
+++ b/src/main/java/com/abcdedu_backend/homework/controller/AdminHomeworkController.java
@@ -3,32 +3,66 @@ import com.abcdedu_backend.common.page.PageManager;
 import com.abcdedu_backend.common.page.request.PagingRequest;
 import com.abcdedu_backend.common.page.request.SortRequest;
 import com.abcdedu_backend.common.page.response.PagedResponse;
+import com.abcdedu_backend.homework.dto.request.RepresentativeRegisterRequest;
+import com.abcdedu_backend.homework.dto.request.modifyRequest;
+import com.abcdedu_backend.homework.dto.request.registerRequest;
 import com.abcdedu_backend.homework.dto.response.HomeworkRes;
-import com.abcdedu_backend.homework.service.HomeworkService;
+import com.abcdedu_backend.homework.service.HomeworkAdminService;
 import com.abcdedu_backend.utils.Response;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 
 @Slf4j
 @RestController
 @RequestMapping("/admin/homeworks")
 @RequiredArgsConstructor
-@Tag(name = "관리자 기능")
+@Tag(name = "관리자 기능 - 공통과제", description = "공통 과제에 대한 관리자 기능을 모아두었습니다.")
 public class AdminHomeworkController {
-    private final HomeworkService homeworkService;
+    private final HomeworkAdminService homeworkAdminService;
+
+    @Operation(summary = "대표 공통과제 등록", description = "메인에 과제로 띄울 대표 버전을 선택한다.")
+    @PostMapping("/representative/{homeworkId}")
+    public Response<Void> registerRepresentative(@Valid @RequestBody RepresentativeRegisterRequest request) {
+        // homeworkAdminService.registerAsRepresentative(request);
+        return Response.success();
+    }
+
     @Operation(summary = "과제 목록", description = "과제 목록을 조회 합니다.")
     @GetMapping
     public Response<PagedResponse<HomeworkRes>> read(PagingRequest pagingRequest, SortRequest sortRequest) {
         PageRequest pageRequest = new PageManager(pagingRequest, sortRequest).makePageRequest();
-        Page<HomeworkRes> homeworks = homeworkService.getHomeworks(pageRequest);
+        Page<HomeworkRes> homeworks = homeworkAdminService.getHomeworks(pageRequest);
         return Response.success(PagedResponse.from(homeworks));
+    }
+
+    @Operation(summary = "공통 과제 상세 조회", description = "과제, 질문이 함께 조회된다.")
+    @GetMapping("/{homeworkId}")
+    public Response<Void> getHomework(@PathVariable Long homeworkId) {
+        return Response.success();
+    }
+
+    @Operation(summary = "공통 과제 등록", description = "여러 개의 질문을 담은 과제를 등록한다.")
+    @PostMapping
+    public Response<Long> createHomework(@Valid @RequestBody registerRequest request) {
+        return Response.success();
+    }
+
+    @Operation(summary = "공통 과제 수정", description = "과제 내용을 수정한다.")
+    @PatchMapping
+    public Response<Void> updateHomework(@Valid @RequestBody modifyRequest request) {
+        return Response.success();
+    }
+
+    @Operation(summary = "공통 과제 삭제")
+    @DeleteMapping("/{homeworkId}")
+    public Response<Void> deleteSurvey(@PathVariable Long homeworkId) {
+        return Response.success();
     }
 }

--- a/src/main/java/com/abcdedu_backend/homework/controller/HomeworkController.java
+++ b/src/main/java/com/abcdedu_backend/homework/controller/HomeworkController.java
@@ -4,6 +4,7 @@ import com.abcdedu_backend.common.jwt.JwtValidation;
 import com.abcdedu_backend.homework.dto.response.HomeworkGetRes;
 import com.abcdedu_backend.homework.dto.request.HomeworkReplyCreateReq;
 import com.abcdedu_backend.homework.service.HomeworkService;
+import com.abcdedu_backend.homework.service.ReadRepresentativeService;
 import com.abcdedu_backend.utils.Response;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -22,11 +23,13 @@ import java.util.List;
 public class HomeworkController {
 
     private final HomeworkService homeworkService;
+    private final ReadRepresentativeService readRepresentativeService;
 
     @Operation(summary = "공통 과제 상세 조회", description = "응답을 하기 위해 문제 내용이 조회된다.")
-    @GetMapping("/{homeworkId}")
-    public Response<HomeworkGetRes> getHomework(@JwtValidation Long memberId, @PathVariable Long homeworkId) {
-        HomeworkGetRes res = homeworkService.getHomework(memberId, homeworkId);
+    @GetMapping
+    public Response<HomeworkGetRes> getHomework(@JwtValidation Long memberId) {
+        Long representativeHomeworkId = readRepresentativeService.readRepresentativeHomework();
+        HomeworkGetRes res = homeworkService.getHomework(memberId, representativeHomeworkId);
         return Response.success(res);
     }
 

--- a/src/main/java/com/abcdedu_backend/homework/dto/request/RepresentativeRegisterRequest.java
+++ b/src/main/java/com/abcdedu_backend/homework/dto/request/RepresentativeRegisterRequest.java
@@ -1,6 +1,9 @@
 package com.abcdedu_backend.homework.dto.request;
 
+import jakarta.annotation.Nullable;
+
 public record RepresentativeRegisterRequest(
+        @Nullable
         Long homeworkId,
         Long memberId
 ) {

--- a/src/main/java/com/abcdedu_backend/homework/dto/request/RepresentativeRegisterRequest.java
+++ b/src/main/java/com/abcdedu_backend/homework/dto/request/RepresentativeRegisterRequest.java
@@ -1,0 +1,7 @@
+package com.abcdedu_backend.homework.dto.request;
+
+public record RepresentativeRegisterRequest(
+        Long homeworkId,
+        Long memberId
+) {
+}

--- a/src/main/java/com/abcdedu_backend/homework/dto/request/modifyRequest.java
+++ b/src/main/java/com/abcdedu_backend/homework/dto/request/modifyRequest.java
@@ -1,0 +1,24 @@
+package com.abcdedu_backend.homework.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record modifyRequest(
+        @Schema(example = "사회 문제 해결을 위한 인공지능 설계")
+        @NotBlank(message = "값이 비었습니다.")
+        String title,
+
+        @Schema(example = "다양한 사례를 통해 인공지능이 사회문제를 해결하기 위해 " +
+                "어떻게 사용되는지 알아보자. 그리고 다음 과제를 수행해보자.")
+        String description,
+
+        @Schema(example = "[인공지능으로 사회문제를 해결한 사례 시청]")
+        String additionalDescription,
+
+        @NotNull(message = "값이 비었습니다.")
+        @Schema(example = "1L 와 같이 과제를 제작하는 로그인된 관리자의 id를 넣어주세요")
+        Long memberId
+) {
+
+}

--- a/src/main/java/com/abcdedu_backend/homework/dto/request/registerRequest.java
+++ b/src/main/java/com/abcdedu_backend/homework/dto/request/registerRequest.java
@@ -1,0 +1,25 @@
+package com.abcdedu_backend.homework.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record registerRequest(
+        @Schema(example = "사회 문제 해결을 위한 인공지능 설계")
+        @NotBlank(message = "값이 비었습니다.")
+        String title,
+
+        @Schema(example = "다양한 사례를 통해 인공지능이 사회문제를 해결하기 위해 " +
+                "어떻게 사용되는지 알아보자. 그리고 다음 과제를 수행해보자.")
+        String description,
+
+        @Schema(example = "[인공지능으로 사회문제를 해결한 사례 시청]")
+        String additionalDescription,
+
+        @NotNull(message = "값이 비었습니다.")
+        @Schema(example = "1L 와 같이 과제를 제작하는 로그인된 관리자의 id를 넣어주세요")
+        Long memberId
+) {
+
+
+}

--- a/src/main/java/com/abcdedu_backend/homework/entity/HomeworkRepresentative.java
+++ b/src/main/java/com/abcdedu_backend/homework/entity/HomeworkRepresentative.java
@@ -26,5 +26,13 @@ public class HomeworkRepresentative extends BaseTimeEntity {
     @ManyToOne
     @JoinColumn(name = "member_id")
     private Member registrant; // 대표 공통과제로 등록한 관리자
+
+    public static HomeworkRepresentative of(Homework homework, Member member) {
+        return HomeworkRepresentative.builder()
+                .homework(homework)
+                .registrant(member)
+                .build();
+
+    }
 }
 

--- a/src/main/java/com/abcdedu_backend/homework/entity/HomeworkRepresentative.java
+++ b/src/main/java/com/abcdedu_backend/homework/entity/HomeworkRepresentative.java
@@ -1,0 +1,30 @@
+package com.abcdedu_backend.homework.entity;
+
+import com.abcdedu_backend.member.entity.Member;
+import com.abcdedu_backend.utils.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+@Entity
+@Table(name = "homework_representatives")
+public class HomeworkRepresentative extends BaseTimeEntity {
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "homework_id", nullable = false)
+    private Homework homework;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member registrant; // 대표 공통과제로 등록한 관리자
+}
+

--- a/src/main/java/com/abcdedu_backend/homework/repository/HomeworkRepresentativeRepository.java
+++ b/src/main/java/com/abcdedu_backend/homework/repository/HomeworkRepresentativeRepository.java
@@ -1,0 +1,14 @@
+package com.abcdedu_backend.homework.repository;
+
+import com.abcdedu_backend.homework.entity.HomeworkRepresentative;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
+
+public interface HomeworkRepresentativeRepository extends JpaRepository<HomeworkRepresentative, Long> {
+
+    @Query("SELECT r FROM HomeworkRepresentative r WHERE r.id = (SELECT MAX(r2.id) FROM HomeworkRepresentative r2)")
+    Optional<HomeworkRepresentative> findLatestRepresentative();
+
+}

--- a/src/main/java/com/abcdedu_backend/homework/service/HomeworkAdminService.java
+++ b/src/main/java/com/abcdedu_backend/homework/service/HomeworkAdminService.java
@@ -1,0 +1,57 @@
+package com.abcdedu_backend.homework.service;
+
+import com.abcdedu_backend.exception.ApplicationException;
+import com.abcdedu_backend.exception.ErrorCode;
+import com.abcdedu_backend.homework.dto.request.RepresentativeRegisterRequest;
+import com.abcdedu_backend.homework.dto.response.HomeworkRes;
+import com.abcdedu_backend.homework.entity.Homework;
+import com.abcdedu_backend.homework.entity.HomeworkRepresentative;
+import com.abcdedu_backend.homework.repository.HomeworkRepository;
+import com.abcdedu_backend.homework.repository.HomeworkRepresentativeRepository;
+import com.abcdedu_backend.member.entity.Member;
+import com.abcdedu_backend.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class HomeworkAdminService {
+    private final HomeworkRepository homeworkRepository;
+    private final HomeworkRepresentativeRepository representativeRepository;
+    private final MemberRepository memberRepository;
+
+    public Page<HomeworkRes> getHomeworks(Pageable pageable) {
+        Page<Homework> homeworks = homeworkRepository.findAll(pageable);
+        log.info("homework repository에서 Page로 데이터 불러오기 성공");
+        return homeworks.map(HomeworkRes::fromHomework);
+    }
+
+    @Transactional
+    public void registerAsRepresentative(RepresentativeRegisterRequest request) {
+        Homework homework = checkHomework(request.homeworkId());
+        Member member = checkMember(request.memberId());
+        try {
+            representativeRepository.save(HomeworkRepresentative.of(homework, member));
+        } catch (Exception e) {
+            throw new ApplicationException(ErrorCode.DATABASE_ERROR);
+        }
+    }
+
+    private Homework checkHomework(Long homeworkId) {
+        Homework homework = homeworkRepository.findById(homeworkId)
+                .orElseThrow(() -> new ApplicationException(ErrorCode.HOMEWORK_NOT_FOUND));
+        return homework;
+    }
+
+    private Member checkMember(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new ApplicationException(ErrorCode.USER_NOT_FOUND));
+        return member;
+    }
+
+}

--- a/src/main/java/com/abcdedu_backend/homework/service/HomeworkService.java
+++ b/src/main/java/com/abcdedu_backend/homework/service/HomeworkService.java
@@ -5,7 +5,6 @@ import com.abcdedu_backend.exception.ErrorCode;
 import com.abcdedu_backend.homework.dto.response.HomeworkGetRes;
 import com.abcdedu_backend.homework.dto.response.HomeworkQuestionGetRes;
 import com.abcdedu_backend.homework.dto.request.HomeworkReplyCreateReq;
-import com.abcdedu_backend.homework.dto.response.HomeworkRes;
 import com.abcdedu_backend.homework.entity.Homework;
 import com.abcdedu_backend.homework.entity.HomeworkQuestion;
 import com.abcdedu_backend.homework.entity.HomeworkReply;
@@ -17,8 +16,6 @@ import com.abcdedu_backend.member.entity.MemberRole;
 import com.abcdedu_backend.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -46,12 +43,6 @@ public class HomeworkService {
         List<HomeworkQuestion> questions = checkQeustionsByHomework(homework);
         List<HomeworkReply> homeworkReplies = makeHomeworkReply(homework, questions, replyRequests, member);
         saveReplies(homeworkReplies);
-    }
-
-    public Page<HomeworkRes> getHomeworks(Pageable pageable) {
-        Page<Homework> homeworks = homeworkRepository.findAll(pageable);
-        log.info("homework repository에서 Page로 데이터 불러오기 성공");
-        return homeworks.map(HomeworkRes::fromHomework);
     }
 
     public Homework checkHomework(Long homeworkId) {

--- a/src/main/java/com/abcdedu_backend/homework/service/ReadRepresentativeService.java
+++ b/src/main/java/com/abcdedu_backend/homework/service/ReadRepresentativeService.java
@@ -1,0 +1,27 @@
+package com.abcdedu_backend.homework.service;
+
+import com.abcdedu_backend.exception.ApplicationException;
+import com.abcdedu_backend.exception.ErrorCode;
+import com.abcdedu_backend.homework.entity.Homework;
+import com.abcdedu_backend.homework.entity.HomeworkRepresentative;
+import com.abcdedu_backend.homework.repository.HomeworkRepresentativeRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ReadRepresentativeService {
+
+    private final HomeworkRepresentativeRepository representativeRepository;
+
+    public Long readRepresentativeHomework() {
+        Homework homework = representativeRepository.findLatestRepresentative()
+                .map(HomeworkRepresentative::getHomework)
+                .orElseThrow(() -> new ApplicationException(ErrorCode.REPRESENTATIVE_HOMEWORK_NOT_FOUND));
+        return homework.getId();
+    }
+
+}

--- a/src/main/resources/db/migration/V2.0.6__add_table_homework_representatives.sql
+++ b/src/main/resources/db/migration/V2.0.6__add_table_homework_representatives.sql
@@ -1,0 +1,10 @@
+-- 공통과제 중 대표 과제 정보를 가진 테이블을 생성한다.
+CREATE TABLE homework_representatives (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    homework_id BIGINT NOT NULL,
+    member_id BIGINT,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    CONSTRAINT fk_homework FOREIGN KEY (homework_id) REFERENCES homeworks (id),
+    CONSTRAINT fk_member FOREIGN KEY (member_id) REFERENCES members (id)
+);

--- a/src/test/java/com/abcdedu_backend/homework/controller/AdminHomeworkControllerTest.java
+++ b/src/test/java/com/abcdedu_backend/homework/controller/AdminHomeworkControllerTest.java
@@ -1,0 +1,56 @@
+package com.abcdedu_backend.homework.controller;
+
+import com.abcdedu_backend.exception.ExceptionManager;
+import com.abcdedu_backend.homework.dto.request.RepresentativeRegisterRequest;
+import com.abcdedu_backend.homework.service.HomeworkAdminService;
+import com.abcdedu_backend.homework.service.HomeworkService;
+import com.google.gson.Gson;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@ExtendWith(MockitoExtension.class)
+class AdminHomeworkControllerTest {
+
+    @InjectMocks
+    private AdminHomeworkController target;
+    @Mock
+    private HomeworkAdminService adminService;
+    @Mock
+    private HomeworkService homeworkService;
+
+    private MockMvc mockMvc;
+    private Gson gson;
+
+    @BeforeEach
+    public void init() {
+        gson = new Gson();
+        mockMvc = MockMvcBuilders.standaloneSetup(target)
+                .setControllerAdvice(new ExceptionManager())
+                .build();
+    }
+
+    @Test
+    void 대표과제_요청양식에_맞게_요청하고_성공하기() throws Exception {
+        //given
+        RepresentativeRegisterRequest request = new RepresentativeRegisterRequest(1L, 1L);
+        // when & then
+        mockMvc.perform(
+                post("/admin/homeworks/representative")
+                        .content(gson.toJson(request))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+
+
+}


### PR DESCRIPTION
## 📝작업 목록
#188 

## 💬기타
Homework_representatives 테이블이 member와 연관관계가 맺어 있어요.

따라서 Homework_representatives 엔티티 save 할 때 member가 들어가야 합니다.

그러려면 homeworkService와 memberService에 의존성이 생겨서 고민하다가,,

service끼리 보단 필요한 service클래스에서 해당 repo에 바로 연결되는게

나중에 의존성 연결할 때 덜 귀찮지 않나 해서 해당 방법 사용했어요..!

혹시 의견 있으시거나 이상한 거 있으면 말씀해주세요 


### 코드리뷰 룰
- P1: 꼭 반영해주세요 (Request changes)
- P2: 적극적으로 고려해주세요 (Request changes)
- P3: 웬만하면 반영해 주세요 (Comment)
- P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- P5: 그냥 사소한 의견입니다 (Approve)
- 참고: https://blog.banksalad.com/tech/banksalad-code-review-culture/